### PR TITLE
Add a byline to Run Support

### DIFF
--- a/www/policies/run-support.spt
+++ b/www/policies/run-support.spt
@@ -1,6 +1,7 @@
 nav_title="Run Support"
 [---]
 [---] text/html via markdown
+*by Paul Fenwick*
 
 ## Support software
 


### PR DESCRIPTION
I think we should have bylines for all of our documentation. This is the author, owner, and maintainer of a document. Maybe this goes against my "everyone commit on master" idea. Maybe we need to revisit that idea. :-)

Eh, @pjf? :-)
