### PR TITLE
Fix travis' heroku deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ deploy:
     branch: master
 
 before_deploy:
+  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
   - cd www/repos
   - git clone https://github.com/gittip/www.gittip.com.git
   - git clone https://github.com/gittip/gttp.co.git


### PR DESCRIPTION
Travis deploy breaks with this error:
https://travis-ci.org/gittip/building.gittip.com/builds/24462180#L286

```
fatal: protocol error: expected old/new/ref, got 'shallow 0557a6ca3f3740eed1fe05cc90f758f143adf01c'
fatal: The remote end hung up unexpectedly
```

Debugging in IRC: https://botbot.me/freenode/gittip/msg/14249130/

It seems that when a travis repo gets to a certain size, travis starts shallow cloning:
https://github.com/JuliaLang/julia/issues/5222#issuecomment-31104141

Might have something to do with travis and heroku using diff git versions:
https://stackoverflow.com/questions/21557004/protocol-error-expected-old-new-ref-got-shallow-deeb

Fix is to "unshallow" before deploy. PR coming.
