### PR TITLE
Simplify our mission

### DIFF
--- a/www/big-picture/mission.spt
+++ b/www/big-picture/mission.spt
@@ -3,4 +3,4 @@ nav_children = []
 [---]
 [---] text/html
 
-Gittip's mission is to enable an economy of gratitude and generosity.
+Gittip's mission is to enable an economy of gratitude, generosity, and love.


### PR DESCRIPTION
The mission/vision statement is verbose. This change boils it down to its essence:

> Gittip's mission is to enable an economy of gratitude and generosity.

I dropped the freighted word "redeem." The verb is now "enable." Rather than defining ourselves in terms of an existent monolithic "economy," I would prefer that we define ourselves in terms of ourselves. My goal is to practice gratitude and generosity. I want to give away my labor as a gift. I don't want to charge for anything I do. Gittip enables me to do that. Other economic arrangements are orthogonal, irrelevant. The baseline criterion of Gittip's success is whether I personally can use it to give money to people and teams that I believe in. The topline criterion is whether I personally can pay my bills from money I receive on Gittip.

Enable is also a less forceful verb than redeem, change, make. We can't _force_ gratitude and generosity. You can lead a horse to water, but. The real work of Gittip happens in the people. The technology we build at best enables an attitude of gratitude in the people, it doesn't manufacture it.
