### PR TITLE
Removes language about on-site event staff

### DIFF
--- a/www/howto/handle-conflict.spt
+++ b/www/howto/handle-conflict.spt
@@ -187,5 +187,5 @@ back trust.
 
 If you believe you or someone else is in physical danger in a Gittip space,
 please notify law enforcement. If you are unsure what law enforcement agency is
-appropriate, contact [conflict@gittip.com](mailto:conflict@gittip.com) or
-on-site event staff, and we will help you.
+appropriate, contact [conflict@gittip.com](mailto:conflict@gittip.com) and we will
+attempt to help you.


### PR DESCRIPTION
Seeing as though Gittip isn't running a conference here, that language is probably unnecessary.
