### PR TITLE
Remove rogue 'r'

### DIFF
--- a/www/howto/onboard-yourself.spt
+++ b/www/howto/onboard-yourself.spt
@@ -9,7 +9,7 @@ If you want to get more deeply involved, here's how to onboard yourself.
 A lot of communications happen via [IRC](/appendices/chat). If you're unsure what to
 do next or have a question, this is a great place to start. If you're not comfortable using IRC
 ping us on Twitter [@Gratipay](http://twitter.com/gratipay) and we'll try and connect you with someone.
-r
+
 ## Support
 
 We use Freshdesk to provide support to people that use Gratipay. See [how to support users](/howto/support-users)


### PR DESCRIPTION
There was a rogue 'r' just hanging out for no good reason on this page. Goodbye, 'r'!