### PR TITLE
Remove web-based chat client

### DIFF
--- a/www/appendices/chat.spt
+++ b/www/appendices/chat.spt
@@ -1,5 +1,0 @@
-nav_title = 'Chat'
-src = "http://webchat.freenode.net/?channels=gratipay"
-[---]
-[---] text/html via jinja2
-{% include "templates/iframed.html" %}

--- a/www/appendices/index.spt
+++ b/www/appendices/index.spt
@@ -1,5 +1,5 @@
 nav_title = 'Appendices'
-nav_children = ['health', 'calendar', 'chat', 'channels', 'finances', 'see-also', 'tools',
+nav_children = ['health', 'calendar', 'channels', 'finances', 'see-also', 'tools',
                 'survey', 'access']
 [---]
 [---] text/html

--- a/www/appendices/tools.spt
+++ b/www/appendices/tools.spt
@@ -24,12 +24,9 @@ linked asterisk\*.
 
 ## Communication
 
-- [BotBot.me][botbot] [\*][botbot-us]
 - [Google+][gplus]    [\*][gplus-us]
 - [Google Hangouts][hangouts]
 - [HuBoard][huboard]  [\*][huboard-us]
-- [Hubot][hubot]
-- [IRC][irc]          [\*][irc-us]
 - [Mandrill][mandrill]
 - [Medium][medium]    [\*][medium-us]
 - [Twitter][twitter]  [\*][twitter-us]
@@ -82,8 +79,6 @@ linked asterisk\*.
 [ally]:         http://www.ally.com/
 [aspen]:        http://aspen.io/
 [balanced]:     https://www.balancedpayments.com/
-[botbot]:       https://botbot.me/
-[botbot-us]:    https://botbot.me/freenode/gratipay/
 [capital-one]:  https://www.capitalone.com/
 [coinbase]:     https://coinbase.com/
 [digitalocean]: https://www.digitalocean.com/
@@ -99,9 +94,6 @@ linked asterisk\*.
 [heroku]:       https://www.heroku.com/
 [huboard]:      https://huboard.com/
 [huboard-us]:   https://huboard.com/gratipay/gratipay.com
-[hubot]:        https://hubot.github.com/
-[irc]:          https://en.wikipedia.org/wiki/Internet_Relay_Chat
-[irc-us]:       http://webchat.freenode.net/?channels=gratipay
 [jinja2]:       http://jinja.pocoo.org/2/
 [librato]:      https://metrics.librato.com/
 [librato-us]:   https://metrics.librato.com/share/dashboards/42hmoj9j?duration=3600&source=production

--- a/www/chat.spt
+++ b/www/chat.spt
@@ -1,3 +1,0 @@
-[---]
-request.redirect('/appendices/chat')
-[---] text/html

--- a/www/howto/advocate-for-users.spt
+++ b/www/howto/advocate-for-users.spt
@@ -2,7 +2,7 @@ nav_title = 'Advocate for Users'
 [---]
 [---] text/html
 
-Gratipay is an open company, which means in part that we conduct all of our internal company discussions in public, primarily using [GitHub](/howto/label-issues) and [IRC](/appendices/chat). This makes it theoretically possible for anyone on the Internet who speaks English to participate in building Gratipay. However, not everyone is comfortable working like this, including some folks who nonetheless want to *use* Gratipay. Just because we conduct our business in public doesn't mean everyone wants to participate on our terms.
+Gratipay is an open company, which means in part that we conduct all of our internal company discussions in public, primarily using [GitHub](/howto/sweep-the-radar). This makes it theoretically possible for anyone on the Internet who speaks English to participate in building Gratipay. However, not everyone is comfortable working like this, including some folks who nonetheless want to *use* Gratipay. Just because we conduct our business in public doesn't mean everyone wants to participate on our terms.
 
 Therefore, we need a go-between. We need someone who *is* comfortable working in public to proxy our users who *aren't*. We need people who can mediate the relationship between communities on Gratipay and Gratipay itself, by participating in our public discussions and representing users that they may be talking to privately.
 

--- a/www/howto/format-source-code.spt
+++ b/www/howto/format-source-code.spt
@@ -17,5 +17,5 @@ And here are a couple house rules (these apply to all languages):
 When in doubt:
 
 - Make it look like existing code.
-- Ask around on IRC or GitHub.
+- Ask on GitHub.
 - Assume we'll flag issues in code review or reformat after the fact.

--- a/www/howto/onboard-yourself.spt
+++ b/www/howto/onboard-yourself.spt
@@ -6,10 +6,6 @@ There are lots of ways to help Gratipay. One is by promoting the concept of gift
 using Gratipay, with widgets and links, and generally [telling people about Gratipay](/howto/tell-people-about-gratipay).
 If you want to get more deeply involved, here's how to onboard yourself.
 
-A lot of communications happen via [IRC](/appendices/chat). If you're unsure what to
-do next or have a question, this is a great place to start. If you're not comfortable using IRC
-ping us on Twitter [@Gratipay](http://twitter.com/gratipay) and we'll try and connect you with someone.
-
 ## Support
 
 We use Freshdesk to provide support to people that use Gratipay. See [how to support users](/howto/support-users)
@@ -22,7 +18,3 @@ Send an email to support@gratipay.com if you'd like to join the support team.
 We could use all sorts of user-focused design & research help.
 See the [discussion about user advocates](https://github.com/gratipay/inside.gratipay.com/issues/56)
 to get started.
-
-Need access to a system? Go look at the [access dashboard](/appendices/access)
-and find someone with admin access to the system you need. Ping them on
-[IRC](/appendices/chat) and ask for access.


### PR DESCRIPTION
We downgraded IRC to a moribund channel in d96b25e10317b33061f7204f65241b6a23a797e0. This PR is to make it a bit more official rather than just doing it in a commit.

Any objections?