### PR TITLE
security program updates

### DIFF
--- a/www/appendices/security-program.md
+++ b/www/appendices/security-program.md
@@ -36,7 +36,7 @@ Please note that our policy is to fully disclose all resolved issues, in the int
 ## Scope
 
 * [https://gratipay.com](https://gratipay.com)
-* [https://grtp.co](https://grtp.co)
+* [https://grtp.co](https://grtp.co) (not in scope for clickjacking)
 * any other [software we publish](https://github.com/gratipay)
 
 ## Out of scope

--- a/www/appendices/security-program.md
+++ b/www/appendices/security-program.md
@@ -26,10 +26,10 @@ Additionally, if you are the first to report the issue, and we make a code or co
 *   Recognize your contribution on HackerOne;
 *   Reward you with a bounty:
 
-  * $100 if you identified a vulnerability that presented a **severe** risk.
-  * $40 if you identified a vulnerability that presented a **moderate** risk.
-  * $10 if you identified a vulnerability that presented a **mild** risk.
-  * $1 if there was in fact **no vulnerability**, but we made a code or configuration change nonetheless.
+  * $100 if you identified a **severe** risk.
+  * $40 if you identified a **moderate** risk.
+  * $10 if you identified a **mild** risk.
+  * $1 if you identified a **theoretical** risk.
 
 Please note that our policy is to fully disclose all resolved issues, in the interest of openness and transparency for our customers.
 

--- a/www/appendices/security-program.md
+++ b/www/appendices/security-program.md
@@ -37,7 +37,6 @@ Please note that our policy is to fully disclose all resolved issues, in the int
 
 * [https://gratipay.com](https://gratipay.com)
 * [https://grtp.co](https://grtp.co)
-* the [Aspen](http://aspen.io/) web framework
 * any other [software we publish](https://github.com/gratipay)
 
 ## Out of scope


### PR DESCRIPTION
Move Aspen out of scope (see https://github.com/AspenWeb/salon/issues/3), and simplify the bounty listing.