### PR TITLE
group disclosures by risk level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.pyc
 local.env
 *.egg-info
+www/appendices/disclosures.json

--- a/www/appendices/disclosures.spt
+++ b/www/appendices/disclosures.spt
@@ -60,22 +60,24 @@ def grouped(all_reports):
               ]
     for report in all_reports:
         for _, lo, reports in groups:
-            bounty = report.get('bounty', 0)
-            bounty = overrides.get(report['id'], bounty)
-            bounty = D(bounty)
-            if bounty > lo:
+            if report['bounty'] > lo:
                 reports.append(report)
                 break
     for header, _, reports in groups:
-        yield header, list(group(reports))
+        reports = list(group(reports))
+        yield header, len(reports), reports
 
 
 raw = get_raw()
 reports = json.loads(raw)
 for report in reports:  # standardize bounty values
-    report['bounty'] = D(report.get('bounty', 0))
+    bounty = report.get('bounty', 0)
+    bounty = overrides.get(report['id'], bounty)
+    report['bounty'] = D(bounty)
 reports.sort(key=lambda r: r['bounty'])
 groups = grouped(reports)
+
+nav_title += ' (N={})'.format(len(reports))
 
 [---] text/html
 <style>
@@ -109,11 +111,13 @@ groups = grouped(reports)
     }
 </style>
 
-*These are all the vulnerability reports we've disclosed through <a
-href="https://hackerone.com/gratipay">our HackerOne program</a>.*
+*These are all the vulnerability reports we've disclosed through [our HackerOne
+program](https://gratipay.com/about/security/hall-of-fame). We disclosed
+another fourteen under [our old
+        program](https://gratipay.com/about/security/hall-of-fame).*
 
-{% for header, group in groups %}
-## {{ header }}
+{% for header, N, group in groups %}
+## {{ header }} (N = {{ N }})
 {% if not group %}
 
 None yet.{% else %}<table class="reports">

--- a/www/appendices/disclosures.spt
+++ b/www/appendices/disclosures.spt
@@ -1,15 +1,28 @@
 import json
 import urllib
+from decimal import Decimal as D
+from os.path import dirname, join
 
 nav_title = 'Security Disclosures'
 nav_children = []
-[---]
-url = 'https://hackerone.com/gratipay/reports/public'
-raw = json.loads(urllib.urlopen(url).read())
 
-def reports():
+# Workaround a limitation in dev where urllib.urlopen often blocks indefinitely(?!)
+# www/appendices/disclosures.json is in .gitignore
+try:
+    raw = open(join(dirname(__file__), 'disclosures.json')).read()
+except IOError:
+    def get_raw():
+        url = 'https://hackerone.com/gratipay/reports/public'
+        return urllib.urlopen(url).read()
+else:
+    def get_raw():
+        return raw
+
+[---]
+
+def group(reports):
     cur = ['9999', '99', '99']
-    for report in raw:
+    for report in reports:
 
         ts = []
         year, month, day = report['disclosed_at'][:10].split('-')
@@ -33,11 +46,40 @@ def reports():
         title = report['title']
         yield ts_mute, ts_pop, url, title
 
+
+def grouped(all_reports):
+    groups = [ ('Severe Risk',                 40, [])
+             , ('Moderate Risk',               10, [])
+             , ('Mild Risk',                    1, [])
+             , ('Theoretical Risk',             0, [])
+             , ('No Risk',          float('-inf'), [])
+              ]
+    for report in all_reports:
+        for _, lo, reports in groups:
+            bounty = D(report.get('bounty', 0))
+            if bounty > lo:
+                reports.append(report)
+                break
+    for header, _, reports in groups:
+        yield header, list(group(reports))
+
+
+raw = get_raw()
+reports = json.loads(raw)
+for report in reports:  # standardize bounty values
+    report['bounty'] = D(report.get('bounty', 0))
+reports.sort(key=lambda r: r['bounty'])
+groups = grouped(reports)
+
 [---] text/html
 <style>
+    h2 {
+        margin: 24px 0 0;
+    }
     .reports {
         display: block;
         width: 100%;
+        margin: 0;
     }
     .reports td {
         padding-bottom: 5px;
@@ -63,15 +105,13 @@ def reports():
     }
 </style>
 
-<p><i>These are all the vulnerability reports we've disclosed through <a
-href="https://hackerone.com/gratipay">our HackerOne program</a>.</i></p>
+*These are all the vulnerability reports we've disclosed through <a
+href="https://hackerone.com/gratipay">our HackerOne program</a>.*
 
-<table class="reports">
-    <tr>
-        <th class="ts">Disclosed</th>
-        <th class="ts">Report</th>
-    </tr>
-    {% for ts_mute, ts_pop, url, title in reports() %}
+{% for header, group in groups %}
+## {{ header }}
+{% if not group %}None yet.{% else %}<table class="reports">
+    {% for ts_mute, ts_pop, url, title in group %}
     <tr>
         <td class="ts">
             <span class="mute">{{ ts_mute }}</span><span class="pop">{{ ts_pop }}</span>
@@ -80,3 +120,5 @@ href="https://hackerone.com/gratipay">our HackerOne program</a>.</i></p>
     </tr>
     {% endfor %}
 </table>
+{% endif %}
+{% endfor %}

--- a/www/appendices/disclosures.spt
+++ b/www/appendices/disclosures.spt
@@ -114,7 +114,9 @@ href="https://hackerone.com/gratipay">our HackerOne program</a>.*
 
 {% for header, group in groups %}
 ## {{ header }}
-{% if not group %}None yet.{% else %}<table class="reports">
+{% if not group %}
+
+None yet.{% else %}<table class="reports">
     {% for ts_mute, ts_pop, url, title in group %}
     <tr>
         <td class="ts">

--- a/www/appendices/disclosures.spt
+++ b/www/appendices/disclosures.spt
@@ -18,6 +18,10 @@ else:
     def get_raw():
         return raw
 
+# Manually override some risk assessments
+overrides = { 76303: '1'  # no bounty awarded because the reporter is part of the Gratipay team
+             }
+
 [---]
 
 def group(reports):
@@ -56,7 +60,9 @@ def grouped(all_reports):
               ]
     for report in all_reports:
         for _, lo, reports in groups:
-            bounty = D(report.get('bounty', 0))
+            bounty = report.get('bounty', 0)
+            bounty = overrides.get(report['id'], bounty)
+            bounty = D(bounty)
             if bounty > lo:
                 reports.append(report)
                 break

--- a/www/appendices/disclosures.spt
+++ b/www/appendices/disclosures.spt
@@ -114,7 +114,10 @@ nav_title += ' (N={})'.format(len(reports))
 *These are all the vulnerability reports we've disclosed through [our HackerOne
 program](https://gratipay.com/about/security/hall-of-fame). We disclosed
 another fourteen under [our old
-        program](https://gratipay.com/about/security/hall-of-fame).*
+        program](https://gratipay.com/about/security/hall-of-fame). See our
+[Security
+        Radar](https://github.com/gratipay/inside.gratipay.com/issues?q=is%3Aopen+label%3ARadar+label%3A%22Security+Team%22)
+for a listing of currently open reports.*
 
 {% for header, N, group in groups %}
 ## {{ header }} (N = {{ N }})

--- a/www/appendices/disclosures.spt
+++ b/www/appendices/disclosures.spt
@@ -83,7 +83,7 @@ groups = grouped(reports)
         margin: 24px 0 0;
     }
     .reports {
-        display: block;
+        table-layout: fixed;
         width: 100%;
         margin: 0;
     }
@@ -93,9 +93,9 @@ groups = grouped(reports)
         white-space: nowrap;
     }
     .reports td.ts {
-        text-align: right;
+        text-align: left;
         font-family: monospace;
-        width: 30%;
+        width: 110px;
     }
     .reports td.ts .mute {
         opacity: 0.2;
@@ -104,8 +104,6 @@ groups = grouped(reports)
         opacity: 1;
     }
     .reports td.link {
-        display: block;
-        width: 70%;
         text-overflow: ellipsis;
         overflow: hidden ! important;
     }

--- a/www/appendices/security-program.md
+++ b/www/appendices/security-program.md
@@ -12,6 +12,7 @@ We ask that all researchers:
 
 *   Make every effort to avoid privacy violations, degradation of user experience, disruption to production systems, and destruction of data during security testing;
 *   Perform research only within the scope set out below;
+*   Review [our "No Risk" disclosures](http://inside.gratipay.com/appendices/disclosures) to avoid filing unwanted reports;
 *   Use the identified communication channels to report vulnerability information to us;
 *   Report vulnerabilities as soon as you discover them; and
 *   Keep information about any vulnerabilities you’ve discovered confidential between yourself and Gratipay until we’ve had 90 days to resolve the issue.


### PR DESCRIPTION
@martijnrusschen added bounties to the disclosure API for us ([FD4640](https://gratipay.freshdesk.com/helpdesk/tickets/4640))—thank you! :D

This PR uses this new info to group disclosures by risk tier (parallel to the grouping on the [Security Radar](https://github.com/gratipay/inside.gratipay.com/issues?q=is%3Aopen+label%3ARadar+label%3A%22Security+Team%22)).

![screen shot 2016-04-14 at 3 27 03 pm](https://cloud.githubusercontent.com/assets/134455/14540890/5e2ab618-0255-11e6-90bb-e2b336204204.png)
