### PR TITLE
Add CSP rule

### DIFF
--- a/templates/page.html
+++ b/templates/page.html
@@ -13,6 +13,14 @@
         <meta property="og:description" content="Documentation for people building Gratipay." />
         <meta property="og:title" content="Inside Gratipay" />
 
+        <meta property="Content-Security-Policy" content="default-src 'none';
+                                                  script-src 'self';
+                                                  style-src 'self' cloud.typography.com;
+                                                  img-src 'self' assets-cdn.github.com;
+                                                  font-src 'self' cloud.typography.com;
+                                                  child-src gratipay-access-dashboard.herokuapp.com www.google.com metrics.librato.com docs.google.com;
+                                                  referrer no-referrer; ">
+
         <link rel="stylesheet" type="text/css"
               href="//cloud.typography.com/6540672/615104/css/fonts.css" />
         <link rel="stylesheet" type="text/css"


### PR DESCRIPTION
Not reported on HackerOne, but often seen as a best practice. I'll do the same for gratipay/gratipay.com but it'll be more complex to be sure to don't break things👌 

The `child-src` may look big but that's what we iframe in the website through the different appendices. The "Finances" page uses the template `iframed` but redirects the user since Github sets the header `X-Frame-Options` to `deny`, so it's not in the list. 