### PR TITLE
Document Unique Transaction ID for MassPay

### DIFF
--- a/www/howto/run-masspay.spt
+++ b/www/howto/run-masspay.spt
@@ -33,9 +33,11 @@ PayPal's MassPay feature.
 1. Download the CSV they give you. It will save as `MassPayment_Details.csv`.
 1. Move the `MassPayment_Details.csv` file to `../logs/masspay/yyyy-mm-dd.report.paypal.csv`.
 1. `cd ../../masspay` and `git commit` the four new files.
-1. `cd` back to the main repo root and run `./env/bin/python ./bin/masspay.py -p` to post back to Gratipay 
-   using the `record-an-exchange` endpoint. When prompted enter your own personal Gratipay 
-   API key. Make sure this works by inspecting the `exchanges` table. **Don't forget this 
-   step!**
+1. `cd` back to the main repo root and run `./env/bin/python ./bin/masspay.py
+   -p` to post back to Gratipay using the `record-an-exchange` endpoint. When
+   prompted enter the &ldquo;Unique Transaction ID&rdquo; shown on the PayPal
+   &ldquo;Transaction details&rdquo; page for the MassPay, and your own personal
+   Gratipay API key. Make sure this works by inspecting the `exchanges` table.
+   **Don't forget this step!**
 1. Note the result on the payday ticket: &ldquo;MassPay done and posted back for N
    users.&rdquo;


### PR DESCRIPTION
We have to enter this manually because PayPal doesn't give it to us in the MassPay report that we download, and we want to use it to compute a unique ref for denied payouts.